### PR TITLE
Hide pattern and theme columns on the verb table

### DIFF
--- a/index.html
+++ b/index.html
@@ -410,8 +410,6 @@
               <th scope="col">Past</th>
               <th scope="col">Past Participle</th>
               <th scope="col">Catalan</th>
-              <th scope="col">Pattern</th>
-              <th scope="col">Theme</th>
               <th scope="col">Progress</th>
               <th scope="col">Actions</th>
             </tr>
@@ -837,8 +835,6 @@
           <td>${verb.past}</td>
           <td>${verb.participle}</td>
           <td>${verb.translation}</td>
-          <td>${verb.pattern}</td>
-          <td>${verb.theme}</td>
           <td><span class="stats-pill ${statsClass}">${total ? `${Math.round(accuracy * 100)}%` : "New"}</span></td>
           <td class="verb-actions">
             <button type="button" data-tts="${verb.base}" data-verb="${verb.base}">🔊 Base</button>


### PR DESCRIPTION
## Summary
- remove the pattern and theme headers from the verb table on the main page
- stop rendering the pattern and theme values for each verb so the table only shows the remaining columns

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd6c1661748333bc2d26b7815e745c