### PR TITLE
Ensure default selections initialize on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -1890,7 +1890,7 @@
       updateDarkModeButton();
     });
 
-    document.addEventListener("DOMContentLoaded", () => {
+    function initializeApp() {
       restoreDarkMode();
       initVoices();
       initializeFilterSelects();
@@ -1899,7 +1899,13 @@
       renderVerbTable(getFilteredVerbs());
       updateProgressSummary();
       renderHardVerbs();
-    });
+    }
+
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", initializeApp, { once: true });
+    } else {
+      initializeApp();
+    }
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- wrap the startup logic in an initializeApp helper
- invoke initialization immediately when the DOM is already ready or after DOMContentLoaded

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e65453decc8333b48b534e45ef4011